### PR TITLE
AngDist::StatTensor::Perturb make func arg const

### DIFF
--- a/src/lib/angdist/StatTensor.cc
+++ b/src/lib/angdist/StatTensor.cc
@@ -203,7 +203,7 @@ namespace GamR {
        @param Gk perturbation factor function, which takes argurments q, q', k, k', t
        @return Statistical tensor after the perturbation for time t
     */
-    StatTensor *StatTensor::Perturbation(std::function<std::complex<double>(double, double, double, double, double)> &Gk, double t)
+    StatTensor *StatTensor::Perturbation(std::function<std::complex<double>(double, double, double, double, double)> const &Gk, double t)
     {
       //std::cout << "PERTURBATION" << std::endl;
       StatTensor *rhoAfter = new StatTensor(this->j);

--- a/src/lib/angdist/StatTensor.hh
+++ b/src/lib/angdist/StatTensor.hh
@@ -40,7 +40,7 @@ namespace GamR {
                                double theta, double phi);
       StatTensor *UnobservedProp(double ji, double lambda, double lambdaPrime, double jf, double delta,
                                  SolidAttenuation *Qk);
-      StatTensor *Perturbation(std::function<std::complex<double>(double, double, double, double, double) > &Gk, double t);
+      StatTensor *Perturbation(std::function<std::complex<double>(double, double, double, double, double) > const &Gk, double t);
       double W(double ji, double lambda, double lambdaPrime, double jf, double delta, SolidAttenuation *Qk, double theta,
                                         double phi);
 


### PR DESCRIPTION
std::function& must also be const to pass functions, otherwise compiler error "cannot bind non-const lvalue reference of type ‘std::function<std::complex<double>(double, double, double, double, double)>&’ to an rvalue of type ‘std::function<std::complex<double>(double, double, double, double, double)>’" results.